### PR TITLE
jQueryの追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "test"
   },
   "dependencies": {
-    "bulma": "0.0.13"
+    "bulma": "0.0.13",
+    "jquery": "^2.2.1"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.5.0",


### PR DESCRIPTION
使用するときは

```
import $ from 'jquery';

// あとはいつも通りjQueryが使えます
$.ajax({
  'type': 'GET'
})
```
